### PR TITLE
Automated release workflow

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,57 @@
+name: Release Application
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.6
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.6
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8
+        pip install -r requirements.txt
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Create executable
+      run: |
+        pyinstaller -i icon.ico -n main --hidden-import=pyttsx3.drivers.sapi5 --onefile speech.py
+        cp ./dist/main.exe 'Bot OP.exe'
+        Compress-Archive Files Driver-Voice-Assistant.zip
+        Compress-Archive 'Bot OP.exe' -Update Driver-Voice-Assistant.zip
+    - name: Create release
+      id: create_release
+      uses: actions/create-release@v1  
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        body: |
+          New release for Driver Bot
+        draft: false
+        prerelease: false
+    - name: Upload Release Asset
+      id: upload-release-asset 
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }} 
+        asset_path: ./Driver-Voice-Assistant.zip
+        asset_name: Driver-Voice-Assistant.zip
+        asset_content_type: application/zip


### PR DESCRIPTION
This workflow build the repo and creates a release zip for new release tag
After adding this workflow you can automatically create release app by following the these steps

## Steps:
1. After preparing project to release in `main` branch run `git tag <tag-version>` on your local machine.
2. Push tag to github using `git push origin --tags`

### Example:
- If you want to release v1.0.0 (release tag should be of format **v[num].[num].[num]** )
- run `git tag v1.0.0` on your local machine
- run `git push origin --tags`
- The workflow will automatically create a release with v1.0.0
![image](https://user-images.githubusercontent.com/25856645/98448328-42b29700-2151-11eb-9230-959a27942b5d.png)
![image](https://user-images.githubusercontent.com/25856645/98448349-5cec7500-2151-11eb-8354-5d7220ac657d.png)
- The file 'Driver-Voice-Assistant.zip' is for release